### PR TITLE
Backend-agnostic API for Lokinit

### DIFF
--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -1,7 +1,8 @@
 use lokinit::prelude::*;
 
 fn main() {
-    core::init::<DefaultLokinitBackend>();
+    // hehe
+    lok::init();
 
     core::create_window(
         WindowBuilder::new()

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -1,6 +1,8 @@
 use lokinit::prelude::*;
 
 fn main() {
+    core::init::<DefaultLokinitBackend>();
+
     core::create_window(
         WindowBuilder::new()
             .title("Hello")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,17 @@ pub mod prelude {
         Event, EventKind, KeyboardEvent, MouseButton, MouseEvent, TouchEvent, TouchPhase,
     };
     pub use crate::keycode::KeyCode;
+    pub use crate::lok;
     pub use crate::native::DefaultLokinitBackend;
     pub use crate::window::{WindowBuilder, WindowHandle, WindowPos, WindowSize};
+}
+
+pub mod lok {
+    use crate::core;
+    use crate::native::DefaultLokinitBackend;
+
+    /// Initializes Lokinit with a default backend.
+    pub fn init() {
+        core::init::<DefaultLokinitBackend>();
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,11 +5,11 @@ mod native;
 pub mod window;
 
 pub mod prelude {
-    pub use crate::core;
-    pub use crate::core::{Monitor, MonitorId};
+    pub use crate::core::{self, Monitor, MonitorId};
     pub use crate::event::{
         Event, EventKind, KeyboardEvent, MouseButton, MouseEvent, TouchEvent, TouchPhase,
     };
     pub use crate::keycode::KeyCode;
+    pub use crate::native::DefaultLokinitBackend;
     pub use crate::window::{WindowBuilder, WindowHandle, WindowPos, WindowSize};
 }

--- a/src/native/linux/dl.rs
+++ b/src/native/linux/dl.rs
@@ -1,6 +1,7 @@
 #![allow(unused)]
 
 use std::ffi::{c_char, c_int, c_void, CStr};
+use std::rc::Rc;
 
 // https://github.com/nagisa/rust_libloading/blob/master/src/os/unix/consts.rs
 pub const RTLD_LAZY: c_int = 1;
@@ -17,12 +18,12 @@ extern "C" {
 }
 
 /// A safe wrapper around dlerror
-pub fn get_dlerror() -> Option<String> {
+pub fn get_dlerror() -> Option<Rc<str>> {
     let err = unsafe { dlerror() };
     if err.is_null() {
         None
     } else {
         let c_str = unsafe { CStr::from_ptr(err) };
-        Some(c_str.to_str().unwrap().to_owned())
+        Some(c_str.to_str().unwrap().into())
     }
 }

--- a/src/native/linux/wayland/mod.rs
+++ b/src/native/linux/wayland/mod.rs
@@ -1,1 +1,1 @@
-
+pub struct WaylandBackend;

--- a/src/native/mod.rs
+++ b/src/native/mod.rs
@@ -22,10 +22,7 @@ pub use android;
 pub use ios;
 
 #[cfg(target_os = "linux")]
-pub use linux::{
-    x11::{CreateWindowError, LokinitCore, NativeCoreError},
-    LoadingError,
-};
+pub type DefaultLokinitBackend = linux::LinuxBackend;
 
 #[cfg(target_os = "macos")]
 pub use macos::{CreateWindowError, LokinitCore, NativeCoreError};


### PR DESCRIPTION
Instead of how we do things now, which is to have a `LokinitCore` struct that contains a subcore from our own native implementation which just so happens to have every function `LokinitCore` needs, we make `LokinitCore` a *trait* with all the functions needed for a backend to implement. That way, not only will our native implementations be slightly cleaner, but *for free* Lokinit will also be expandable to whatever people feel like implementing themselves.